### PR TITLE
Fix nginx template to not break when 'location_extra' includes 'auth_…

### DIFF
--- a/roles/nginx/templates/host.j2
+++ b/roles/nginx/templates/host.j2
@@ -42,10 +42,12 @@ server {
 
 {% if item.get('zodb_path') != None %}
   location / {
+{%     if 'auth_basic ' not in item.get('location_extra', '') %}
     auth_basic off;
-    {% if item.get('location_extra') != None %}
-      {{ item.location_extra }}
-    {% endif %}
+{%     endif %}
+{%     if item.get('location_extra') != None %}
+    {{   item.location_extra }}
+{%     endif %}
     rewrite ^/(.*)$ /VirtualHostBase/$vh_protocol/$server_name:$vh_port{{ item.zodb_path }}/VirtualHostRoot/$1 break;
     proxy_pass http://localhost:{{ proxycache_port|default('6081') }};
   }


### PR DESCRIPTION
…basic'

Avoids the nginx error: 2016/07/19 17:29:33 [emerg] 31936#0: auth_basic directive duplicate in /etc/nginx/sites-enabled/http_demob_me_com:20